### PR TITLE
test(e2e): add waitlist CTA refresh wiring verification test

### DIFF
--- a/e2e/fixtures/board-state-all-occupied.json
+++ b/e2e/fixtures/board-state-all-occupied.json
@@ -1,0 +1,28 @@
+{
+  "ok": true,
+  "serverNow": "2025-01-23T10:00:00Z",
+  "courts": [
+    { "number": 1, "status": "occupied", "session": { "id": "s1", "players": [{"name": "Player 1", "memberId": "p1"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 2, "status": "occupied", "session": { "id": "s2", "players": [{"name": "Player 2", "memberId": "p2"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 3, "status": "occupied", "session": { "id": "s3", "players": [{"name": "Player 3", "memberId": "p3"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 4, "status": "occupied", "session": { "id": "s4", "players": [{"name": "Player 4", "memberId": "p4"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 5, "status": "occupied", "session": { "id": "s5", "players": [{"name": "Player 5", "memberId": "p5"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 6, "status": "occupied", "session": { "id": "s6", "players": [{"name": "Player 6", "memberId": "p6"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 7, "status": "occupied", "session": { "id": "s7", "players": [{"name": "Player 7", "memberId": "p7"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 8, "status": "occupied", "session": { "id": "s8", "players": [{"name": "Player 8", "memberId": "p8"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 9, "status": "occupied", "session": { "id": "s9", "players": [{"name": "Player 9", "memberId": "p9"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 10, "status": "occupied", "session": { "id": "s10", "players": [{"name": "Player 10", "memberId": "p10"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 11, "status": "occupied", "session": { "id": "s11", "players": [{"name": "Player 11", "memberId": "p11"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 12, "status": "occupied", "session": { "id": "s12", "players": [{"name": "Player 12", "memberId": "p12"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null }
+  ],
+  "waitlist": [
+    {
+      "id": "entry-1",
+      "position": 1,
+      "players": [{ "name": "Waiting Player", "memberId": "W001" }],
+      "joinedAt": "2025-01-23T09:30:00Z"
+    }
+  ],
+  "upcomingBlocks": [],
+  "operatingHours": { "opensAt": "07:00", "closesAt": "21:00" }
+}

--- a/e2e/fixtures/board-state-one-available.json
+++ b/e2e/fixtures/board-state-one-available.json
@@ -1,0 +1,28 @@
+{
+  "ok": true,
+  "serverNow": "2025-01-23T10:05:00Z",
+  "courts": [
+    { "number": 1, "status": "available", "session": null, "block": null },
+    { "number": 2, "status": "occupied", "session": { "id": "s2", "players": [{"name": "Player 2", "memberId": "p2"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 3, "status": "occupied", "session": { "id": "s3", "players": [{"name": "Player 3", "memberId": "p3"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 4, "status": "occupied", "session": { "id": "s4", "players": [{"name": "Player 4", "memberId": "p4"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 5, "status": "occupied", "session": { "id": "s5", "players": [{"name": "Player 5", "memberId": "p5"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 6, "status": "occupied", "session": { "id": "s6", "players": [{"name": "Player 6", "memberId": "p6"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 7, "status": "occupied", "session": { "id": "s7", "players": [{"name": "Player 7", "memberId": "p7"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 8, "status": "occupied", "session": { "id": "s8", "players": [{"name": "Player 8", "memberId": "p8"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 9, "status": "occupied", "session": { "id": "s9", "players": [{"name": "Player 9", "memberId": "p9"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 10, "status": "occupied", "session": { "id": "s10", "players": [{"name": "Player 10", "memberId": "p10"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 11, "status": "occupied", "session": { "id": "s11", "players": [{"name": "Player 11", "memberId": "p11"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null },
+    { "number": 12, "status": "occupied", "session": { "id": "s12", "players": [{"name": "Player 12", "memberId": "p12"}], "startedAt": "2025-01-23T09:00:00Z" }, "block": null }
+  ],
+  "waitlist": [
+    {
+      "id": "entry-1",
+      "position": 1,
+      "players": [{ "name": "Waiting Player", "memberId": "W001" }],
+      "joinedAt": "2025-01-23T09:30:00Z"
+    }
+  ],
+  "upcomingBlocks": [],
+  "operatingHours": { "opensAt": "07:00", "closesAt": "21:00" }
+}

--- a/e2e/waitlist-cta-refresh.spec.js
+++ b/e2e/waitlist-cta-refresh.spec.js
@@ -1,0 +1,53 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { setupMockApi } from './helpers/mock-api.js';
+import { loadFixture } from './helpers/fixtures.js';
+
+test.describe('Waitlist CTA Refresh Wiring', () => {
+
+  test('CTA updates when court becomes available after refresh', async ({ page }) => {
+    // Capture page errors BEFORE navigation
+    const pageErrors = [];
+    page.on('pageerror', error => pageErrors.push(error.message));
+
+    // Load fixtures for sequencing
+    const allOccupied = loadFixture('board-state-all-occupied');
+    const oneAvailable = loadFixture('board-state-one-available');
+
+    // Setup with queue:
+    // - First get-board returns all courts occupied (no CTA)
+    // - Second get-board (after reload) returns one court available (CTA visible)
+    await setupMockApi(page, {
+      boardStateQueue: [allOccupied, oneAvailable]
+    });
+
+    // Navigate to registration (same URL as existing waitlist test)
+    await page.goto('src/registration/index.html?e2e=1');
+
+    // Wait for app to load (same selector as existing waitlist test)
+    await expect(page.locator('#main-search-input')).toBeVisible({ timeout: 10000 });
+
+    // INITIAL STATE: Assert waitlist CTA is NOT visible
+    // (all courts occupied, so no "Play Now" option for waitlisted member)
+    const waitlistCta = page.locator('[data-testid="waitlist-cta-1"]');
+    await expect(waitlistCta).toHaveCount(0, { timeout: 5000 });
+
+    // Trigger refresh (reload to get second board state)
+    await page.reload();
+
+    // Wait for app to reload
+    await expect(page.locator('#main-search-input')).toBeVisible({ timeout: 10000 });
+
+    // AFTER REFRESH: Assert waitlist CTA IS visible
+    // (one court available, so "Play Now" option appears for waitlisted member)
+    await expect(waitlistCta).toBeVisible({ timeout: 5000 });
+
+    // Assert no crashes
+    const crashErrors = pageErrors.filter(e =>
+      e.includes('Cannot read properties of null') ||
+      e.includes('Cannot read properties of undefined') ||
+      e.includes('TypeError')
+    );
+    expect(crashErrors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
- New fixtures: board-state-all-occupied, board-state-one-available
- Test verifies CTA updates when court becomes available after refresh
- Uses proven selectors from waitlist-cta-flow.spec.js
- Refresh wiring test - no multi-endpoint choreography

🤖 Generated with [Claude Code](https://claude.com/claude-code)