### PR TITLE
Fix React lifecycle leaks and stale closures in registration hooks

### DIFF
--- a/src/registration/appHandlers/handlers/courtHandlers.ts
+++ b/src/registration/appHandlers/handlers/courtHandlers.ts
@@ -169,7 +169,7 @@ export function useCourtHandlers({
   const { getCourtData } = helpers;
   const { getCourtBlockStatus } = blockAdmin;
   const { showAlertMessage } = alert;
-  const { successResetTimerRef } = refs;
+  const { successResetTimerRef, changeCourtTimerRef } = refs;
   const { clearSuccessResetTimer, resetForm, isPlayerAlreadyPlaying } = core;
 
   // VERBATIM COPY: saveCourtData from line ~206
@@ -308,6 +308,7 @@ export function useCourtHandlers({
         currentWaitlistEntryId,
         CONSTANTS,
         successResetTimerRef,
+        changeCourtTimerRef,
         API_CONFIG,
       },
       actions: {
@@ -354,6 +355,7 @@ export function useCourtHandlers({
       currentWaitlistEntryId,
       CONSTANTS,
       successResetTimerRef,
+      changeCourtTimerRef,
       API_CONFIG,
       setIsAssigning,
       setCurrentWaitlistEntryId,

--- a/src/registration/appHandlers/state/buildRegistrationReturn.ts
+++ b/src/registration/appHandlers/state/buildRegistrationReturn.ts
@@ -206,6 +206,7 @@ export function buildRegistrationReturn({
     refs: {
       successResetTimerRef: runtime.successResetTimerRef,
       typingTimeoutRef: runtime.typingTimeoutRef,
+      changeCourtTimerRef: runtime.changeCourtTimerRef,
     },
 
     // Derived/computed values

--- a/src/registration/appHandlers/state/useRegistrationDataLayer.ts
+++ b/src/registration/appHandlers/state/useRegistrationDataLayer.ts
@@ -1,5 +1,5 @@
-import { useEffect, useCallback } from "react";
-import { logger } from "../../../lib/logger";
+import { useEffect, useCallback, useRef } from 'react';
+import { logger } from '../../../lib/logger';
 import type {
   TennisBackendShape,
   RegistrationUiState,
@@ -9,18 +9,22 @@ import type {
   OperatingHoursEntry,
   ApiMember,
   CourtSelectionResult,
-} from "../../../types/appTypes";
+} from '../../../types/appTypes';
 
 type Updater<T> = (value: T | ((prev: T) => T)) => void;
 
 interface UseRegistrationDataLayerDeps {
   backend: TennisBackendShape;
-  setData: Updater<RegistrationUiState["data"]>;
+  setData: Updater<RegistrationUiState['data']>;
   setAvailableCourts: (courts: number[]) => void;
   setOperatingHours: (hours: OperatingHoursEntry[] | null) => void;
   setApiMembers: (members: ApiMember[]) => void;
-  data: RegistrationUiState["data"];
-  computeRegistrationCourtSelection: (courts: DomainCourt[], upcomingBlocks?: UpcomingBlock[]) => CourtSelectionResult;
+  /** Present in the deps interface for call-site stability; not read inside the hook. */
+  data?: RegistrationUiState['data'];
+  computeRegistrationCourtSelection: (
+    courts: DomainCourt[],
+    upcomingBlocks?: UpcomingBlock[]
+  ) => CourtSelectionResult;
 }
 
 /**
@@ -36,7 +40,6 @@ export function useRegistrationDataLayer({
   setAvailableCourts,
   setOperatingHours,
   setApiMembers,
-  data,
   computeRegistrationCourtSelection,
 }: UseRegistrationDataLayerDeps) {
   const loadData = useCallback(async () => {
@@ -50,7 +53,6 @@ export function useRegistrationDataLayer({
       const updatedData = {
         courts: courts,
         waitlist: waitlist,
-        recentlyCleared: data.recentlyCleared || [],
       };
       setData((prev) => ({ ...prev, ...updatedData }));
       if (boardData.operatingHours) {
@@ -63,29 +65,51 @@ export function useRegistrationDataLayer({
       const selectableNumbers = selection.selectableCourts.map((sc) => sc.number);
       setAvailableCourts(selectableNumbers);
       setData((prev) => ({ ...prev, courtSelection: selection }));
-      logger.debug("DataLayer", "Initial load complete", {
+      logger.debug('DataLayer', 'Initial load complete', {
         courts: courts.length,
         waitlist: waitlist.length,
         members: (members as unknown[]).length,
       });
       return updatedData;
     } catch (error) {
-      logger.error("DataLayer", "Failed to load data", error);
+      logger.error('DataLayer', 'Failed to load data', error);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only: backend is stable singleton
   }, [backend]);
 
+  // Hold latest setters / selection-computer in refs so the mount-only
+  // subscription callback always sees the current closures, not the ones
+  // captured on first render.
+  const subscriptionDepsRef = useRef({
+    setData,
+    setOperatingHours,
+    setAvailableCourts,
+    computeRegistrationCourtSelection,
+  });
+  subscriptionDepsRef.current = {
+    setData,
+    setOperatingHours,
+    setAvailableCourts,
+    computeRegistrationCourtSelection,
+  };
+
   useEffect(() => {
-    logger.debug("DataLayer", "[TennisBackend] Setting up board subscription...");
+    logger.debug('DataLayer', '[TennisBackend] Setting up board subscription...');
     const unsubscribe = backend.queries.subscribeToBoardChanges(
       (domainBoard: DomainBoard) => {
+        const {
+          setData: currentSetData,
+          setOperatingHours: currentSetOperatingHours,
+          setAvailableCourts: currentSetAvailableCourts,
+          computeRegistrationCourtSelection: currentCompute,
+        } = subscriptionDepsRef.current;
         const board = domainBoard;
-        logger.debug("DataLayer", "[TennisBackend] Board update received", {
+        logger.debug('DataLayer', '[TennisBackend] Board update received', {
           serverNow: board.serverNow,
           courts: (board.courts as unknown[] | undefined)?.length,
           waitlist: (board.waitlist as unknown[] | undefined)?.length,
         });
-        setData((prev) => ({
+        currentSetData((prev) => ({
           ...prev,
           courts: board.courts || [],
           waitlist: board.waitlist || [],
@@ -93,18 +117,15 @@ export function useRegistrationDataLayer({
           upcomingBlocks: board.upcomingBlocks || [],
         }));
         if (board.operatingHours) {
-          setOperatingHours(board.operatingHours as OperatingHoursEntry[]);
+          currentSetOperatingHours(board.operatingHours as OperatingHoursEntry[]);
         }
-        const selection = computeRegistrationCourtSelection(
-          board.courts || [],
-          board.upcomingBlocks || []
-        );
+        const selection = currentCompute(board.courts || [], board.upcomingBlocks || []);
         const selectable = selection.selectableCourts.map((sc) => sc.number);
-        setAvailableCourts(selectable);
-        setData((prev) => ({ ...prev, courtSelection: selection }));
+        currentSetAvailableCourts(selectable);
+        currentSetData((prev) => ({ ...prev, courtSelection: selection }));
         logger.debug(
-          "DataLayer",
-          "[Registration CTA Debug] Courts from API",
+          'DataLayer',
+          '[Registration CTA Debug] Courts from API',
           board.courts?.map((c) => ({
             num: c.number,
             isBlocked: c.isBlocked,
@@ -116,13 +137,12 @@ export function useRegistrationDataLayer({
       },
       { pollIntervalMs: 5000 }
     );
-    logger.debug("DataLayer", "[TennisBackend] Board subscription active");
+    logger.debug('DataLayer', '[TennisBackend] Board subscription active');
     return () => {
-      logger.debug("DataLayer", "[TennisBackend] Unsubscribing from board updates");
+      logger.debug('DataLayer', '[TennisBackend] Unsubscribing from board updates');
       unsubscribe();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only: board subscription setup, backend is stable singleton
-  }, []);
+  }, [backend]);
 
   return {
     loadData,

--- a/src/registration/appHandlers/state/useRegistrationRuntime.ts
+++ b/src/registration/appHandlers/state/useRegistrationRuntime.ts
@@ -31,6 +31,7 @@ export function useRegistrationRuntime({
   // ===== REFS =====
   const successResetTimerRef = useRef(null);
   const typingTimeoutRef = useRef(null);
+  const changeCourtTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // ===== EFFECTS =====
 
@@ -138,9 +139,22 @@ export function useRegistrationRuntime({
 
   // Cleanup typing timeout on unmount
   useEffect(() => {
-    const timeoutId = typingTimeoutRef.current;
     return () => {
-      if (timeoutId) clearTimeout(timeoutId);
+      if (typingTimeoutRef.current) {
+        clearTimeout(typingTimeoutRef.current);
+        typingTimeoutRef.current = null;
+      }
+    };
+  }, []);
+
+  // Cleanup change-court countdown interval on unmount
+  // (fire-and-forget timer started by directAssignment branch; kiosk may run for weeks)
+  useEffect(() => {
+    return () => {
+      if (changeCourtTimerRef.current) {
+        clearInterval(changeCourtTimerRef.current);
+        changeCourtTimerRef.current = null;
+      }
     };
   }, []);
 
@@ -148,5 +162,6 @@ export function useRegistrationRuntime({
     // Refs (needed by handlers)
     successResetTimerRef,
     typingTimeoutRef,
+    changeCourtTimerRef,
   };
 }

--- a/src/registration/orchestration/assignCourtOrchestrator.ts
+++ b/src/registration/orchestration/assignCourtOrchestrator.ts
@@ -71,6 +71,7 @@ export interface AssignCourtState {
   CONSTANTS: RegistrationConstants;
   API_CONFIG: ApiConfig;
   successResetTimerRef: { current: ReturnType<typeof setTimeout> | null };
+  changeCourtTimerRef: { current: ReturnType<typeof setInterval> | null };
 }
 
 export interface AssignCourtActions {

--- a/src/registration/orchestration/branches/directAssignment.ts
+++ b/src/registration/orchestration/branches/directAssignment.ts
@@ -166,10 +166,15 @@ export async function executeDirectAssignment(
   startAutoResetTimer(state, services);
 
   if (allowCourtChange) {
+    // Any prior countdown is stale — clear before starting a new one
+    if (state.changeCourtTimerRef.current) {
+      clearInterval(state.changeCourtTimerRef.current);
+    }
     const timer = setInterval(() => {
       actions.setChangeTimeRemaining((prev: number) => {
         if (prev <= 1) {
           clearInterval(timer);
+          state.changeCourtTimerRef.current = null;
           actions.setCanChangeCourt(false);
           // Don't call resetForm() - let user decide when to leave
           return 0;
@@ -177,6 +182,7 @@ export async function executeDirectAssignment(
         return prev - 1;
       });
     }, 1000);
+    state.changeCourtTimerRef.current = timer;
   }
 
   // Explicit refresh to ensure fresh state (belt-and-suspenders with Realtime)

--- a/src/types/appTypes.ts
+++ b/src/types/appTypes.ts
@@ -192,9 +192,7 @@ export interface TennisBackendShape {
     // Evidence: TennisQueries.js:201 — delegates to getBoard
     refresh: () => Promise<DomainBoard>;
     // Evidence: TennisQueries.js:218 — returns { ok, partners: [{member_id, display_name, ...}] }
-    getFrequentPartners: (
-      memberId: string
-    ) => Promise<
+    getFrequentPartners: (memberId: string) => Promise<
       CommandResponse & {
         partners?: Array<{
           member_id: string;
@@ -398,9 +396,7 @@ export interface TennisBackendShape {
       end: string;
     }) => Promise<CommandResponse & { summary?: Record<string, unknown>; heatmap?: unknown[] }>;
     // Evidence: AdminCommands.js:379 — returns CommandResponse & { heatmap?, daysAnalyzed? }
-    getUsageAnalytics: (
-      days?: number
-    ) => Promise<
+    getUsageAnalytics: (days?: number) => Promise<
       CommandResponse & {
         heatmap?: Array<{ day_of_week: number; hour: number; session_count: number }>;
         daysAnalyzed?: number;
@@ -703,6 +699,8 @@ export interface RegistrationRefs {
   successResetTimerRef: { current: ReturnType<typeof setTimeout> | null };
   /** Timer ref for typing debounce */
   typingTimeoutRef: { current: ReturnType<typeof setTimeout> | null };
+  /** Interval ref for change-court countdown (started by directAssignment branch) */
+  changeCourtTimerRef: { current: ReturnType<typeof setInterval> | null };
 }
 
 export interface DerivedState {

--- a/tests/unit/orchestration/assignCourtOrchestrator.test.ts
+++ b/tests/unit/orchestration/assignCourtOrchestrator.test.ts
@@ -53,6 +53,7 @@ function createMockDeps(overrides: Record<string, any> = {}) {
       IS_MOBILE: false,
     },
     successResetTimerRef: { current: null },
+    changeCourtTimerRef: { current: null },
     ...overrides.state,
   };
 

--- a/tests/unit/registration/appHandlers/state/useRegistrationDataLayer.test.ts
+++ b/tests/unit/registration/appHandlers/state/useRegistrationDataLayer.test.ts
@@ -90,18 +90,20 @@ describe('loadData', () => {
     expect(deps.backend.directory.getAllMembers).toHaveBeenCalledTimes(1);
   });
 
-  it('calls setData with merged board data preserving recentlyCleared', async () => {
+  it('calls setData with merged board data preserving prev state', async () => {
     await result.current.loadData();
 
-    // setData called with updater function (first call for board data)
+    // setData called with updater function (first call for board data).
+    // recentlyCleared must come from prev state via functional spread,
+    // not from a closure-captured snapshot.
     expect(deps.setData).toHaveBeenCalled();
     const firstUpdater = deps.setData.mock.calls[0][0];
-    const merged = firstUpdater({ existing: true });
+    const merged = firstUpdater({ existing: true, recentlyCleared: ['court-9'] });
     expect(merged).toMatchObject({
       existing: true,
       courts: [{ number: 1, isAvailable: true }],
       waitlist: [{ id: 'w1' }],
-      recentlyCleared: ['court-5'],
+      recentlyCleared: ['court-9'],
     });
   });
 


### PR DESCRIPTION
Four related issues in the registration runtime:

- Typing-timeout cleanup captured typingTimeoutRef.current at mount (always null), so the debounce timer was never cleared. Read the ref inside the returned cleanup instead.

- Change-court countdown setInterval in directAssignment was fire-and- forget: React had no way to clear it on unmount. On a kiosk that may run for weeks, navigating away mid-countdown triggered state updates on an unmounted tree. Threaded a new changeCourtTimerRef through runtime → RegistrationRefs → AssignCourtState, cleared on unmount, and cleared any prior timer before starting a new one.

- Board-subscription effect had [] deps but referenced setters and computeRegistrationCourtSelection via closure. Since computeRegistrationCourtSelection is typically a fresh function per render, the subscription kept calling the original closure forever. Routed all callbacks through subscriptionDepsRef, updated every render.

- loadData merged data.recentlyCleared from its closure, which could clobber newer values. Removed the redundant merge; prev state in the functional setter already preserves recentlyCleared via spread.

Tests updated: orchestrator fixture now includes changeCourtTimerRef; dataLayer test asserts recentlyCleared is preserved via prev spread rather than from a captured snapshot.