### PR TITLE
Fix 4 domain-correctness bugs that surface wrong behavior to users

### DIFF
--- a/src/lib/backend/TennisCommands.ts
+++ b/src/lib/backend/TennisCommands.ts
@@ -43,7 +43,10 @@ export class TennisCommands {
   api: import('../ApiAdapter').ApiAdapter;
   directory: import('./TennisDirectory').TennisDirectory | undefined;
 
-  constructor(apiAdapter: import('../ApiAdapter').ApiAdapter, directory?: import('./TennisDirectory').TennisDirectory) {
+  constructor(
+    apiAdapter: import('../ApiAdapter').ApiAdapter,
+    directory?: import('./TennisDirectory').TennisDirectory
+  ) {
     this.api = apiAdapter;
     this.directory = directory;
   }
@@ -160,7 +163,17 @@ export class TennisCommands {
    * @param {number} [params.longitude] - For mobile geofence validation
    * @returns {Promise<import('./types').CommandResponse & { session?: Object }>}
    */
-  async assignFromWaitlistWithLocation({ waitlistEntryId, courtId, latitude, longitude }: { waitlistEntryId: string; courtId: string; latitude?: number; longitude?: number }) {
+  async assignFromWaitlistWithLocation({
+    waitlistEntryId,
+    courtId,
+    latitude,
+    longitude,
+  }: {
+    waitlistEntryId: string;
+    courtId: string;
+    latitude?: number;
+    longitude?: number;
+  }) {
     return this.assignFromWaitlist({
       waitlistEntryId,
       courtId,
@@ -176,7 +189,13 @@ export class TennisCommands {
    * @param {string} params.takeoverSessionId - UUID of the session that caused displacement
    * @returns {Promise<import('./types').CommandResponse & { restoredSessionId?: string }>}
    */
-  async restoreSession({ displacedSessionId, takeoverSessionId }: { displacedSessionId: string; takeoverSessionId: string }) {
+  async restoreSession({
+    displacedSessionId,
+    takeoverSessionId,
+  }: {
+    displacedSessionId: string;
+    takeoverSessionId: string;
+  }) {
     const response = await this.api.post('/restore-session', {
       displaced_session_id: displacedSessionId,
       takeover_session_id: takeoverSessionId,
@@ -193,7 +212,13 @@ export class TennisCommands {
    * @param {string} params.displacedSessionId - UUID of the session that was displaced
    * @returns {Promise<import('./types').CommandResponse & { endedSessionId?: string, restoredSessionId?: string }>}
    */
-  async undoOvertimeTakeover({ takeoverSessionId, displacedSessionId }: { takeoverSessionId: string; displacedSessionId: string }) {
+  async undoOvertimeTakeover({
+    takeoverSessionId,
+    displacedSessionId,
+  }: {
+    takeoverSessionId: string;
+    displacedSessionId: string;
+  }) {
     const response = await this.api.post('/undo-overtime-takeover', {
       takeover_session_id: takeoverSessionId,
       displaced_session_id: displacedSessionId,
@@ -312,7 +337,9 @@ export class TennisCommands {
    *   { kind: 'member', memberId: uuid, accountId: uuid }
    *   { kind: 'guest', guestName: string, accountId: uuid }
    */
-  async resolvePlayersToParticipants(players: Array<Record<string, unknown>>): Promise<import('./types').ParticipantInput[]> {
+  async resolvePlayersToParticipants(
+    players: Array<Record<string, unknown>>
+  ): Promise<import('./types').ParticipantInput[]> {
     if (!this.directory) {
       throw new AppError({
         category: ErrorCategories.VALIDATION,
@@ -378,28 +405,60 @@ export class TennisCommands {
     let firstMemberAccount: string | null = null;
 
     for (const player of memberPlayers) {
-      const members = (membersByAccount.get(player.memberNumber as string) || []) as Array<Record<string, unknown>>;
+      const members = (membersByAccount.get(player.memberNumber as string) || []) as Array<
+        Record<string, unknown>
+      >;
       const nameLower = ((player.name as string) || '').toLowerCase().trim();
 
-      // Find matching member (exact match, then partial, then last name)
-      // Members are already normalized by TennisDirectory - use camelCase only
-      let member = members.find((m) => ((m.displayName as string | undefined) || '').toLowerCase().trim() === nameLower);
+      const displayOf = (m: Record<string, unknown>) =>
+        ((m.displayName as string | undefined) || '').toLowerCase().trim();
 
+      // Tier 1: exact displayName match (preferred — unambiguous)
+      let member = members.find((m) => displayOf(m) === nameLower);
+
+      // Tier 2: partial match (displayName contains name or vice-versa).
+      // Only accept if it picks out a single member — otherwise we'd silently
+      // sign up the wrong person when multiple family members share a substring.
       if (!member) {
-        // Partial match
-        member = members.find((m) => {
-          const display = ((m.displayName as string | undefined) || '').toLowerCase().trim();
+        const partialMatches = members.filter((m) => {
+          const display = displayOf(m);
           return display.includes(nameLower) || nameLower.includes(display);
         });
+        if (partialMatches.length === 1) {
+          member = partialMatches[0];
+        } else if (partialMatches.length > 1) {
+          throw new AppError({
+            category: ErrorCategories.VALIDATION,
+            code: 'AMBIGUOUS_MEMBER',
+            message: `Multiple members on account ${player.memberNumber} match "${player.name}". Please be more specific.`,
+            details: {
+              searched: player.name,
+              candidates: partialMatches.map((m) => m.displayName as string),
+            },
+          });
+        }
       }
 
+      // Tier 3: last-name match. Same ambiguity guard.
       if (!member) {
-        // Last name match
-        member = members.find((m) => {
-          const displayLast = ((m.displayName as string | undefined) || '').toLowerCase().split(' ').pop();
-          const nameLast = nameLower.split(' ').pop();
+        const nameLast = nameLower.split(' ').pop();
+        const lastNameMatches = members.filter((m) => {
+          const displayLast = displayOf(m).split(' ').pop();
           return displayLast === nameLast;
         });
+        if (lastNameMatches.length === 1) {
+          member = lastNameMatches[0];
+        } else if (lastNameMatches.length > 1) {
+          throw new AppError({
+            category: ErrorCategories.VALIDATION,
+            code: 'AMBIGUOUS_MEMBER',
+            message: `Multiple members on account ${player.memberNumber} share the last name in "${player.name}". Please be more specific.`,
+            details: {
+              searched: player.name,
+              candidates: lastNameMatches.map((m) => m.displayName as string),
+            },
+          });
+        }
       }
 
       if (!member && members.length === 1) {
@@ -520,7 +579,9 @@ export class TennisCommands {
 
     // 2. Resolve players to participants (member lookup)
     // Type assertion: GroupPlayer[] lacks the index signature required by Array<Record<string,unknown>>; resolvePlayersToParticipants accesses legacy fields (type, clubNumber) not in GroupPlayer
-    const participants = await this.resolvePlayersToParticipants(players as unknown as Array<Record<string, unknown>>);
+    const participants = await this.resolvePlayersToParticipants(
+      players as unknown as Array<Record<string, unknown>>
+    );
     logger.debug('TennisCommands', 'Resolved participants', {
       durationMs: (performance.now() - tStart).toFixed(0),
     });
@@ -558,7 +619,19 @@ export class TennisCommands {
    * @param {boolean} [params.deferred] - Wait for Full Time flow
    * @returns {Promise<import('./types').CommandResponse & { entry?: Object, position?: number }>}
    */
-  async joinWaitlistWithPlayers({ players, groupType, latitude, longitude, deferred }: { players: GroupPlayer[]; groupType: 'singles' | 'doubles'; latitude?: number; longitude?: number; deferred?: boolean }) {
+  async joinWaitlistWithPlayers({
+    players,
+    groupType,
+    latitude,
+    longitude,
+    deferred,
+  }: {
+    players: GroupPlayer[];
+    groupType: 'singles' | 'doubles';
+    latitude?: number;
+    longitude?: number;
+    deferred?: boolean;
+  }) {
     // 1. Validate command structure (fail-fast)
     // INPUT-NORMALIZE: Accept either format from UI, normalize to camelCase for validation
     const validPlayers = players.map((p) => ({
@@ -574,7 +647,9 @@ export class TennisCommands {
 
     // 2. Resolve players to participants (member lookup)
     // Type assertion: GroupPlayer[] lacks the index signature required by Array<Record<string,unknown>>; resolvePlayersToParticipants accesses legacy fields (type, clubNumber) not in GroupPlayer
-    const participants = await this.resolvePlayersToParticipants(players as unknown as Array<Record<string, unknown>>);
+    const participants = await this.resolvePlayersToParticipants(
+      players as unknown as Array<Record<string, unknown>>
+    );
 
     // 3. Send to API
     return this.joinWaitlist({
@@ -593,7 +668,13 @@ export class TennisCommands {
    * @param {boolean} input.isTournament - Whether this is a tournament match
    * @returns {Promise<import('./types').CommandResponse>}
    */
-  async updateSessionTournament({ sessionId, isTournament }: { sessionId: string; isTournament: boolean }) {
+  async updateSessionTournament({
+    sessionId,
+    isTournament,
+  }: {
+    sessionId: string;
+    isTournament: boolean;
+  }) {
     const response = await this.api.post('/update-session-tournament', {
       session_id: sessionId,
       is_tournament: isTournament,

--- a/src/registration/appHandlers/state/useRegistrationRuntime.ts
+++ b/src/registration/appHandlers/state/useRegistrationRuntime.ts
@@ -49,30 +49,35 @@ export function useRegistrationRuntime({
     };
   }, []);
 
-  // VERBATIM COPY: Fetch ball price from API on mount (line 678)
-  // Normalize settings at boundary
+  // Fetch ball price + block-warning minutes from API on mount.
+  // Normalize settings at boundary.
   useEffect(() => {
-    const fetchBallPrice = async () => {
+    const fetchSettings = async () => {
       try {
         const result = await backend.admin.getSettings();
-        if (result.ok) {
-          const settings = normalizeSettings(result.settings);
-          if (settings?.ballPriceCents) {
-            setBallPriceCents(settings.ballPriceCents as number);
-          }
-          if (settings?.blockWarningMinutes) {
-            const blockWarnMin = parseInt(settings.blockWarningMinutes as string, 10);
-            if (blockWarnMin > 0) {
-              setBlockWarningMinutes(blockWarnMin);
-            }
+        if (!result.ok) {
+          logger.warn('RegistrationRuntime', 'getSettings returned ok:false', {
+            code: (result as { code?: string }).code,
+            message: (result as { message?: string }).message,
+          });
+          return;
+        }
+        const settings = normalizeSettings(result.settings);
+        if (settings?.ballPriceCents) {
+          setBallPriceCents(settings.ballPriceCents as number);
+        }
+        if (settings?.blockWarningMinutes) {
+          const blockWarnMin = parseInt(settings.blockWarningMinutes as string, 10);
+          if (blockWarnMin > 0) {
+            setBlockWarningMinutes(blockWarnMin);
           }
         }
       } catch (error) {
-        console.error('Failed to load ball price from API:', error);
+        logger.error('RegistrationRuntime', 'Failed to load settings from API', error);
       }
     };
-    fetchBallPrice();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only: fetch ball price once on init
+    fetchSettings();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only: fetch settings once on init
   }, []);
 
   // VERBATIM COPY: CSS Performance Optimizations (line 750)

--- a/src/registration/orchestration/branches/waitlistAssignment.ts
+++ b/src/registration/orchestration/branches/waitlistAssignment.ts
@@ -119,8 +119,18 @@ export async function executeWaitlistAssignment(
 
     startAutoResetTimer(state, services);
 
-    // Explicit refresh to ensure fresh state (belt-and-suspenders with Realtime)
-    await services.backend.queries.refresh();
+    // Explicit refresh to ensure fresh state (belt-and-suspenders with Realtime).
+    // Best-effort only: the assignment already succeeded above; a refresh
+    // failure must not surface as "Failed to assign court from waitlist".
+    try {
+      await services.backend.queries.refresh();
+    } catch (refreshError) {
+      getRuntimeDeps().logger.warn(
+        'AssignCourt',
+        'Post-waitlist-assignment refresh failed (assignment still succeeded)',
+        refreshError
+      );
+    }
 
     // EARLY-EXIT: waitlist flow complete — success screen shown
     actions.setIsAssigning(false);

--- a/src/tennis/domain/availability.ts
+++ b/src/tennis/domain/availability.ts
@@ -5,6 +5,8 @@
  * Ported from domain/availability.js IIFE.
  */
 
+import { logger } from '../../lib/logger';
+
 // Registration buffer: treat blocks as starting this many minutes earlier
 const REGISTRATION_BUFFER_MINUTES = 15;
 const REGISTRATION_BUFFER_MS = REGISTRATION_BUFFER_MINUTES * 60 * 1000;
@@ -38,18 +40,41 @@ type CourtData = {
   }>;
 };
 
-
-
 /**
- * Helper for robust date handling
- * @param {Date|string} d - Date or string to coerce
- * @returns {Date} Valid Date object
+ * Sanitize a trusted `now` input. If caller passed a non-Date or invalid
+ * Date, fall back to the current wall-clock. Used only for the `now`
+ * parameter — never for block data (use `parseDate` for that).
  */
 function coerceDate(d: Date | string): Date {
-  // Accept Date or string; never NaN
-  if (d instanceof Date) return d;
+  if (d instanceof Date && !isNaN(d.getTime())) return d;
   const parsed = new Date(d);
   return isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
+/**
+ * Parse a possibly-invalid block timestamp. Returns null on invalid input
+ * so callers can skip malformed blocks explicitly instead of treating them
+ * as "just ended" (which silently removes them from availability checks).
+ */
+function parseDate(d: Date | string | null | undefined): Date | null {
+  if (d == null || d === '') return null;
+  if (d instanceof Date) return isNaN(d.getTime()) ? null : d;
+  const parsed = new Date(d);
+  return isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function blockInterval(b: CourtBlock): { start: Date; end: Date } | null {
+  const start = parseDate((b.startTime ?? b.start) as Date | string | null | undefined);
+  const end = parseDate((b.endTime ?? b.end) as Date | string | null | undefined);
+  if (!start || !end) {
+    logger.warn('Availability', 'Skipping block with invalid start/end', {
+      courtNumber: b.courtNumber ?? b.court,
+      startTime: b.startTime ?? b.start,
+      endTime: b.endTime ?? b.end,
+    });
+    return null;
+  }
+  return { start, end };
 }
 
 /**
@@ -58,10 +83,15 @@ function coerceDate(d: Date | string): Date {
  * @param {Date} now - Current time
  * @returns {boolean} True if session is overtime
  */
-function isOvertime(session: { scheduledEndAt?: string | Date } | null | undefined, now: Date): boolean {
+function isOvertime(
+  session: { scheduledEndAt?: string | Date } | null | undefined,
+  now: Date
+): boolean {
   // Domain format: session.scheduledEndAt
   if (!session?.scheduledEndAt) return false;
-  return coerceDate(session.scheduledEndAt) <= now; // strict "ended before or at now"
+  const end = parseDate(session.scheduledEndAt);
+  if (!end) return false;
+  return end <= now; // strict "ended before or at now"
 }
 
 /**
@@ -126,7 +156,17 @@ function isActiveBlock(b: CourtBlock | null | undefined, now: Date): boolean {
  * @param {Set} params.wetSet - Set of wet court numbers
  * @returns {number[]} Array of free court numbers
  */
-function getFreeCourts({ data, now, blocks = [], wetSet = new Set() }: { data: CourtData; now: Date; blocks?: CourtBlock[]; wetSet?: Set<number> }) {
+function getFreeCourts({
+  data,
+  now,
+  blocks = [],
+  wetSet = new Set(),
+}: {
+  data: CourtData;
+  now: Date;
+  blocks?: CourtBlock[];
+  wetSet?: Set<number>;
+}) {
   if (!data || !data.courts || !Array.isArray(data.courts)) {
     throw new Error('Invalid data or courts array provided');
   }
@@ -167,10 +207,10 @@ function getFreeCourts({ data, now, blocks = [], wetSet = new Set() }: { data: C
       const courtNum = Number(block.courtNumber || block.court);
       if (!courtNum || courtNum !== courtNumber) return false;
 
-      const blockStart = coerceDate((block.startTime || block.start) ?? '');
-      const blockEnd = coerceDate((block.endTime || block.end) ?? '');
+      const interval = blockInterval(block);
+      if (!interval) return false;
 
-      return blockStart <= now && now < blockEnd;
+      return interval.start <= now && now < interval.end;
     });
 
     if (isBlocked) {
@@ -193,7 +233,17 @@ function getFreeCourts({ data, now, blocks = [], wetSet = new Set() }: { data: C
  * @param {number} params.requiredMinutes - Required minutes
  * @returns {boolean} True if conflict exists
  */
-function hasSoonBlockConflict({ courtNumber, now, blocks = [], requiredMinutes = 60 }: { courtNumber: number; now: Date; blocks?: CourtBlock[]; requiredMinutes?: number }) {
+function hasSoonBlockConflict({
+  courtNumber,
+  now,
+  blocks = [],
+  requiredMinutes = 60,
+}: {
+  courtNumber: number;
+  now: Date;
+  blocks?: CourtBlock[];
+  requiredMinutes?: number;
+}) {
   if (typeof courtNumber !== 'number' || courtNumber < 1) {
     throw new Error('Invalid court number provided');
   }
@@ -212,13 +262,13 @@ function hasSoonBlockConflict({ courtNumber, now, blocks = [], requiredMinutes =
   return blocks.some((block) => {
     if (block.courtNumber !== courtNumber) return false;
 
-    const blockStart = coerceDate(block.startTime as string | Date);
-    const blockEnd = coerceDate(block.endTime as string | Date);
+    const interval = blockInterval(block);
+    if (!interval) return false;
 
     // Check if block overlaps with our required time window
     // Block conflicts if:
     // 1. Block starts before our session ends AND block ends after our session starts
-    return blockStart < requiredEndTime && blockEnd > now;
+    return interval.start < requiredEndTime && interval.end > now;
   });
 }
 
@@ -241,14 +291,30 @@ function hasSoonBlockConflict({ courtNumber, now, blocks = [], requiredMinutes =
  * @param {Set} params.wetSet - Set of wet court numbers
  * @returns {Date[]} Array of next free times per court
  */
-function getNextFreeTimes({ data, now, blocks, wetSet }: { data: CourtData; now: Date; blocks?: CourtBlock[]; wetSet?: Set<number> }) {
+function getNextFreeTimes({
+  data,
+  now,
+  blocks,
+  wetSet,
+}: {
+  data: CourtData;
+  now: Date;
+  blocks?: CourtBlock[];
+  wetSet?: Set<number>;
+}) {
   const total = window.Tennis?.Config?.Courts?.TOTAL_COUNT ?? 12;
   const out: Date[] = new Array(total);
-  const byCourt = (blocks || []).map((b) => ({
-    courtNumber: Number(b.courtNumber),
-    start: coerceDate(b.startTime as string | Date),
-    end: coerceDate(b.endTime as string | Date),
-  }));
+  const byCourt = (blocks || []).flatMap((b) => {
+    const interval = blockInterval(b);
+    if (!interval) return [];
+    return [
+      {
+        courtNumber: Number(b.courtNumber),
+        start: interval.start,
+        end: interval.end,
+      },
+    ];
+  });
   // Normalize wetSet
   const wet = wetSet instanceof Set ? wetSet : new Set();
 
@@ -298,7 +364,17 @@ function getNextFreeTimes({ data, now, blocks, wetSet }: { data: CourtData; now:
  * @param {Set} params.wetSet - Set of wet court numbers
  * @returns {Object} Free courts info
  */
-function getFreeCourtsInfo({ data, now, blocks, wetSet }: { data: CourtData; now: Date; blocks?: CourtBlock[]; wetSet?: Set<number> }) {
+function getFreeCourtsInfo({
+  data,
+  now,
+  blocks,
+  wetSet,
+}: {
+  data: CourtData;
+  now: Date;
+  blocks?: CourtBlock[];
+  wetSet?: Set<number>;
+}) {
   const total = window.Tennis?.Config?.Courts?.TOTAL_COUNT ?? 12;
   const all = Array.from({ length: total }, (_, i) => i + 1);
 
@@ -320,9 +396,9 @@ function getFreeCourtsInfo({ data, now, blocks, wetSet }: { data: CourtData; now
     const isBlocked = blocks.some((b) => {
       const courtNum = Number(b.courtNumber || b.court);
       if (!courtNum || courtNum !== n) return false;
-      const start = coerceDate((b.startTime || b.start) ?? '');
-      const end = coerceDate((b.endTime || b.end) ?? '');
-      return start <= now && now < end;
+      const interval = blockInterval(b);
+      if (!interval) return false;
+      return interval.start <= now && now < interval.end;
     });
 
     if (isWet || isBlocked) continue;
@@ -365,7 +441,17 @@ function getFreeCourtsInfo({ data, now, blocks, wetSet }: { data: CourtData; now
  * @param {Set} params.wetSet - Set of wet court numbers
  * @returns {number[]} Array of selectable court numbers
  */
-function getSelectableCourts({ data, now, blocks, wetSet }: { data: CourtData; now: Date; blocks?: CourtBlock[]; wetSet?: Set<number> }) {
+function getSelectableCourts({
+  data,
+  now,
+  blocks,
+  wetSet,
+}: {
+  data: CourtData;
+  now: Date;
+  blocks?: CourtBlock[];
+  wetSet?: Set<number>;
+}) {
   const info = getFreeCourtsInfo({ data, now, blocks, wetSet });
 
   // Active, non-wet blocks set (by courtNumber)
@@ -399,7 +485,19 @@ function getSelectableCourts({ data, now, blocks, wetSet }: { data: CourtData; n
  * @param {Array} [params.upcomingBlocks] - Upcoming blocks for usability check
  * @returns {Object[]} Array of court status objects
  */
-function getCourtStatuses({ data, now, blocks, wetSet, upcomingBlocks = [] }: { data: CourtData; now: Date; blocks?: CourtBlock[]; wetSet?: Set<number>; upcomingBlocks?: CourtBlock[] }) {
+function getCourtStatuses({
+  data,
+  now,
+  blocks,
+  wetSet,
+  upcomingBlocks = [],
+}: {
+  data: CourtData;
+  now: Date;
+  blocks?: CourtBlock[];
+  wetSet?: Set<number>;
+  upcomingBlocks?: CourtBlock[];
+}) {
   const info = getFreeCourtsInfo({ data, now, blocks, wetSet });
 
   // sets for quick lookup
@@ -426,14 +524,13 @@ function getCourtStatuses({ data, now, blocks, wetSet, upcomingBlocks = [] }: { 
     hasTrueFree &&
     [...freeSet].some((courtNum) => {
       if (!upcomingBlocks || upcomingBlocks.length === 0) return true;
-      const nextBlock = upcomingBlocks.find(
-        (b) =>
-          Number(b.courtNumber || b.court) === courtNum && coerceDate((b.startTime || b.start) as string | Date) > now
-      );
-      if (!nextBlock) return true;
-      return (
-        coerceDate((nextBlock.startTime || nextBlock.start) as string | Date).getTime() - now.getTime() >= MIN_USEFUL_MS
-      );
+      const nextBlockStart = upcomingBlocks
+        .filter((b) => Number(b.courtNumber || b.court) === courtNum)
+        .map((b) => parseDate((b.startTime || b.start) as Date | string | null | undefined))
+        .filter((d): d is Date => d !== null && d > now)
+        .sort((a, b) => a.getTime() - b.getTime())[0];
+      if (!nextBlockStart) return true;
+      return nextBlockStart.getTime() - now.getTime() >= MIN_USEFUL_MS;
     });
 
   const total = (data?.courts || []).length || info.meta?.total || 0;
@@ -502,7 +599,7 @@ function getCourtStatuses({ data, now, blocks, wetSet, upcomingBlocks = [] }: { 
     // selectable reason for styling
     const selectableReason = selectable ? (status === 'free' ? 'free' : 'overtime_fallback') : null;
 
-const courtStatus: CourtStatus = {
+    const courtStatus: CourtStatus = {
       courtNumber: n,
       status,
       selectable,
@@ -534,7 +631,17 @@ const courtStatus: CourtStatus = {
  * @param {Set} params.wetSet - Set of wet court numbers
  * @returns {number[]} Array of assignable court numbers
  */
-function getSelectableCourtsForAssignment({ data, now, blocks, wetSet }: { data: CourtData; now: Date; blocks?: CourtBlock[]; wetSet?: Set<number> }) {
+function getSelectableCourtsForAssignment({
+  data,
+  now,
+  blocks,
+  wetSet,
+}: {
+  data: CourtData;
+  now: Date;
+  blocks?: CourtBlock[];
+  wetSet?: Set<number>;
+}) {
   // Use existing selectable logic but enforce stricter rules for assignment
   const selectable = getSelectableCourts({ data, now, blocks, wetSet });
 
@@ -556,7 +663,15 @@ function getSelectableCourtsForAssignment({ data, now, blocks, wetSet }: { data:
  * @param {Set} params.wetSet - Set of wet court numbers
  * @returns {boolean} True if court can be assigned
  */
-function canAssignToCourt(courtNumber: number, { data, now, blocks, wetSet }: { data: CourtData; now: Date; blocks?: CourtBlock[]; wetSet?: Set<number> }) {
+function canAssignToCourt(
+  courtNumber: number,
+  {
+    data,
+    now,
+    blocks,
+    wetSet,
+  }: { data: CourtData; now: Date; blocks?: CourtBlock[]; wetSet?: Set<number> }
+) {
   const assignable = getSelectableCourtsForAssignment({ data, now, blocks, wetSet });
   return assignable.includes(courtNumber);
 }
@@ -570,7 +685,17 @@ function canAssignToCourt(courtNumber: number, { data, now, blocks, wetSet }: { 
  * @param {Set} params.wetSet - Set of wet court numbers
  * @returns {number[]} Array of strictly selectable court numbers
  */
-function getSelectableCourtsStrict({ data, now, blocks = [], wetSet = new Set() }: { data: CourtData; now: Date; blocks?: CourtBlock[]; wetSet?: Set<number> }) {
+function getSelectableCourtsStrict({
+  data,
+  now,
+  blocks = [],
+  wetSet = new Set(),
+}: {
+  data: CourtData;
+  now: Date;
+  blocks?: CourtBlock[];
+  wetSet?: Set<number>;
+}) {
   const info = getFreeCourtsInfo({ data, now, blocks, wetSet });
   const free = info.free || [];
   const overtime = info.overtime || [];
@@ -589,11 +714,19 @@ function getSelectableCourtsStrict({ data, now, blocks = [], wetSet = new Set() 
  * @param {Set} params.wetSet - Set of wet court numbers
  * @returns {boolean} True if waitlist join should be allowed
  */
-function shouldAllowWaitlistJoin({ data, now, blocks = [], wetSet = new Set() }: { data: CourtData; now: Date; blocks?: CourtBlock[]; wetSet?: Set<number> }) {
+function shouldAllowWaitlistJoin({
+  data,
+  now,
+  blocks = [],
+  wetSet = new Set(),
+}: {
+  data: CourtData;
+  now: Date;
+  blocks?: CourtBlock[];
+  wetSet?: Set<number>;
+}) {
   const strict = getSelectableCourtsStrict({ data, now, blocks, wetSet });
-  return (
-strict.length === 0
-  );
+  return strict.length === 0;
 }
 
 // ============================================================

--- a/tests/unit/lib/backend/TennisCommands.test.ts
+++ b/tests/unit/lib/backend/TennisCommands.test.ts
@@ -204,9 +204,7 @@ describe('TennisCommands', () => {
     it('createBlock — throws on missing courtId', async () => {
       const { commands } = setup();
 
-      await expect(
-        commands.createBlock({ courtId: '', reason: 'test' })
-      ).rejects.toThrow();
+      await expect(commands.createBlock({ courtId: '', reason: 'test' })).rejects.toThrow();
     });
 
     it('cancelBlock — validates then posts to /cancel-block', async () => {
@@ -435,10 +433,16 @@ describe('TennisCommands', () => {
     });
 
     it('fetches unique member numbers only (deduplication)', async () => {
-      const getMembersByAccount = vi.fn().mockResolvedValue([
-        { ...ALICE },
-        { id: 'member-uuid-alice-jr', accountId: 'account-uuid-1001', displayName: 'Alice Smith Jr' },
-      ]);
+      const getMembersByAccount = vi
+        .fn()
+        .mockResolvedValue([
+          { ...ALICE },
+          {
+            id: 'member-uuid-alice-jr',
+            accountId: 'account-uuid-1001',
+            displayName: 'Alice Smith Jr',
+          },
+        ]);
       const { commands } = setup({ directory: { getMembersByAccount } });
 
       await commands.resolvePlayersToParticipants([
@@ -454,9 +458,9 @@ describe('TennisCommands', () => {
     it('matches by partial name when exact fails', async () => {
       const { commands } = setup({
         directory: {
-          getMembersByAccount: vi.fn().mockResolvedValue([
-            { id: 'M1', accountId: 'A1', displayName: 'Alexander Hamilton' },
-          ]),
+          getMembersByAccount: vi
+            .fn()
+            .mockResolvedValue([{ id: 'M1', accountId: 'A1', displayName: 'Alexander Hamilton' }]),
         },
       });
 
@@ -471,9 +475,9 @@ describe('TennisCommands', () => {
     it('matches by last name when exact and partial fail', async () => {
       const { commands } = setup({
         directory: {
-          getMembersByAccount: vi.fn().mockResolvedValue([
-            { id: 'M1', accountId: 'A1', displayName: 'Robert Hamilton' },
-          ]),
+          getMembersByAccount: vi
+            .fn()
+            .mockResolvedValue([{ id: 'M1', accountId: 'A1', displayName: 'Robert Hamilton' }]),
         },
       });
 
@@ -488,9 +492,11 @@ describe('TennisCommands', () => {
     it('uses single member on account as fallback', async () => {
       const { commands } = setup({
         directory: {
-          getMembersByAccount: vi.fn().mockResolvedValue([
-            { id: 'M1', accountId: 'A1', displayName: 'Completely Different Name' },
-          ]),
+          getMembersByAccount: vi
+            .fn()
+            .mockResolvedValue([
+              { id: 'M1', accountId: 'A1', displayName: 'Completely Different Name' },
+            ]),
         },
       });
 
@@ -513,18 +519,16 @@ describe('TennisCommands', () => {
       });
 
       await expect(
-        commands.resolvePlayersToParticipants([
-          { name: 'Nobody Matching', memberNumber: '1001' },
-        ])
+        commands.resolvePlayersToParticipants([{ name: 'Nobody Matching', memberNumber: '1001' }])
       ).rejects.toThrow('Could not find member: Nobody Matching');
     });
 
     it('throws when member has no member number', async () => {
       const { commands } = setup();
 
-      await expect(
-        commands.resolvePlayersToParticipants([{ name: 'No Number' }])
-      ).rejects.toThrow('has no member number');
+      await expect(commands.resolvePlayersToParticipants([{ name: 'No Number' }])).rejects.toThrow(
+        'has no member number'
+      );
     });
 
     it('resolves guest players with __NEEDS_ACCOUNT__ then assigns first member account', async () => {
@@ -612,9 +616,7 @@ describe('TennisCommands', () => {
         },
       });
 
-      await commands.resolvePlayersToParticipants([
-        { name: 'Alice Smith', clubNumber: '1001' },
-      ]);
+      await commands.resolvePlayersToParticipants([{ name: 'Alice Smith', clubNumber: '1001' }]);
 
       expect(directory.getMembersByAccount).toHaveBeenCalledWith('1001');
     });
@@ -705,9 +707,7 @@ describe('TennisCommands', () => {
       // Uses displayName instead of name, memberId instead of id
       await commands.assignCourtWithPlayers({
         courtId: 'C1',
-        players: [
-          { memberId: 'p1', displayName: 'Alice Smith', memberNumber: '1001' } as any,
-        ],
+        players: [{ memberId: 'p1', displayName: 'Alice Smith', memberNumber: '1001' } as any],
         groupType: 'singles',
       });
 
@@ -803,7 +803,7 @@ describe('TennisCommands', () => {
         expect.unreachable('should have thrown');
       } catch (e) {
         expect(e).toBeInstanceOf(AppError);
-        expect((e as AppError)).toBeInstanceOf(Error);
+        expect(e as AppError).toBeInstanceOf(Error);
         expect((e as AppError).category).toBe('VALIDATION');
         expect((e as AppError).code).toBe('DIRECTORY_NOT_SET');
         expect((e as AppError).message).toContain('TennisDirectory not set');
@@ -818,7 +818,7 @@ describe('TennisCommands', () => {
         expect.unreachable('should have thrown');
       } catch (e) {
         expect(e).toBeInstanceOf(AppError);
-        expect((e as AppError)).toBeInstanceOf(Error);
+        expect(e as AppError).toBeInstanceOf(Error);
         expect((e as AppError).category).toBe('VALIDATION');
         expect((e as AppError).code).toBe('MISSING_MEMBER_NUMBER');
         expect((e as AppError).message).toContain('has no member number');
@@ -842,7 +842,7 @@ describe('TennisCommands', () => {
         expect.unreachable('should have thrown');
       } catch (e) {
         expect(e).toBeInstanceOf(AppError);
-        expect((e as AppError)).toBeInstanceOf(Error);
+        expect(e as AppError).toBeInstanceOf(Error);
         expect((e as AppError).category).toBe('NOT_FOUND');
         expect((e as AppError).code).toBe('MEMBER_NOT_FOUND');
         expect((e as AppError).message).toContain('Could not find member');
@@ -853,16 +853,57 @@ describe('TennisCommands', () => {
       const { commands } = setup();
 
       try {
+        await commands.resolvePlayersToParticipants([{ name: 'Guest 1', isGuest: true }]);
+        expect.unreachable('should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(AppError);
+        expect(e as AppError).toBeInstanceOf(Error);
+        expect((e as AppError).category).toBe('VALIDATION');
+        expect((e as AppError).code).toBe('GUESTS_WITHOUT_MEMBER');
+        expect((e as AppError).message).toContain('Cannot register guests without a member');
+      }
+    });
+
+    it('AMBIGUOUS_MEMBER — throws when partial match picks multiple family members', async () => {
+      const { commands } = setup({
+        directory: {
+          getMembersByAccount: vi.fn().mockResolvedValue([
+            { id: 'M1', accountId: 'A1', displayName: 'Bob Smith' },
+            { id: 'M2', accountId: 'A1', displayName: 'Bobby Smith' },
+          ]),
+        },
+      });
+
+      try {
+        await commands.resolvePlayersToParticipants([{ name: 'Bob', memberNumber: '1001' }]);
+        expect.unreachable('should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(AppError);
+        expect((e as AppError).category).toBe('VALIDATION');
+        expect((e as AppError).code).toBe('AMBIGUOUS_MEMBER');
+        expect((e as AppError).message).toContain('Bob');
+      }
+    });
+
+    it('AMBIGUOUS_MEMBER — throws when last-name match picks multiple family members', async () => {
+      const { commands } = setup({
+        directory: {
+          getMembersByAccount: vi.fn().mockResolvedValue([
+            { id: 'M1', accountId: 'A1', displayName: 'Jon Anderson' },
+            { id: 'M2', accountId: 'A1', displayName: 'Sally Anderson' },
+          ]),
+        },
+      });
+
+      try {
         await commands.resolvePlayersToParticipants([
-          { name: 'Guest 1', isGuest: true },
+          { name: 'Pat Anderson', memberNumber: '1001' },
         ]);
         expect.unreachable('should have thrown');
       } catch (e) {
         expect(e).toBeInstanceOf(AppError);
-        expect((e as AppError)).toBeInstanceOf(Error);
         expect((e as AppError).category).toBe('VALIDATION');
-        expect((e as AppError).code).toBe('GUESTS_WITHOUT_MEMBER');
-        expect((e as AppError).message).toContain('Cannot register guests without a member');
+        expect((e as AppError).code).toBe('AMBIGUOUS_MEMBER');
       }
     });
   });

--- a/tests/unit/registration/appHandlers/state/useRegistrationRuntime.test.ts
+++ b/tests/unit/registration/appHandlers/state/useRegistrationRuntime.test.ts
@@ -129,19 +129,19 @@ describe('settings fetch', () => {
   });
 
   it('does not crash when getSettings rejects', async () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { logger } = await import('../../../../../src/lib/logger.js');
     deps = createDeps();
     deps.backend.admin.getSettings.mockRejectedValue(new Error('network'));
     unmount();
     ({ result, unmount } = await renderHandlerHook(() => useRegistrationRuntime(deps)));
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      'Failed to load ball price from API:',
+    expect(logger.error).toHaveBeenCalledWith(
+      'RegistrationRuntime',
+      'Failed to load settings from API',
       expect.any(Error)
     );
     expect(deps.setBallPriceCents).not.toHaveBeenCalled();
-    consoleSpy.mockRestore();
   });
 });
 
@@ -197,9 +197,7 @@ describe('ref returns', () => {
 describe('CSS style injection', () => {
   it('injects a style element into document.head on mount', () => {
     const styles = document.head.querySelectorAll('style');
-    const injected = Array.from(styles).find((s) =>
-      s.textContent.includes('.animate-pulse')
-    );
+    const injected = Array.from(styles).find((s) => s.textContent.includes('.animate-pulse'));
     expect(injected).toBeTruthy();
     expect(injected!.textContent).toContain('will-change: opacity');
     expect(injected!.textContent).toContain('.court-transition');


### PR DESCRIPTION
1. availability.coerceDate: invalid block dates silently coerced to "now", making malformed blocks disappear from free/overtime/next-free calculations. Split into coerceDate (sanitizes trusted `now` input) and parseDate (returns null for invalid); add blockInterval() helper that logs + skips blocks with bad timestamps so issues are visible instead of hidden. Also fixes isOvertime flagging invalid scheduledEndAt as overtime.

2. waitlistAssignment: the final best-effort refresh() was inside the outer try, so a network failure after a successful waitlist assignment rolled the user back to an error toast ("Failed to assign court from waitlist") even though the court was actually booked. Wrap the final refresh in its own try/catch, mirroring directAssignment.

3. useRegistrationRuntime.fetchBallPrice: used console.error instead of logger and ignored ok:false responses silently. Renamed to fetchSettings, route both error paths through logger so operators see why ball price / block-warning-minutes silently fell back to defaults.

4. TennisCommands.resolvePlayersToParticipants: partial-name and last-name matching returned the first hit, so when two family members shared an account, the wrong person could be silently signed up. Reject ambiguous matches with AMBIGUOUS_MEMBER (VALIDATION) so users see a clear error instead of a wrong-person registration.