### PR TITLE
Fix ESLint architecture boundaries that rotted during JS→TS migration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,11 @@ export default [
       'react-hooks/exhaustive-deps': 'warn',
       'react/react-in-jsx-scope': 'off',
       'react/prop-types': 'off',
+      // WP4-4: camelCase enforcement (boundary files exempted below)
+      camelcase: [
+        'warn',
+        { properties: 'never', ignoreDestructuring: true, ignoreImports: true },
+      ],
     },
   },
   // TypeScript files — use TS parser, no React rules (pure logic files)
@@ -64,6 +69,11 @@ export default [
       'no-undef': 'off', // TypeScript handles this
       'no-redeclare': 'off', // TypeScript handles this (interfaces merge)
       'react-hooks/exhaustive-deps': 'warn',
+      // WP4-4: camelCase enforcement (boundary files exempted below)
+      camelcase: [
+        'warn',
+        { properties: 'never', ignoreDestructuring: true, ignoreImports: true },
+      ],
     },
   },
   {
@@ -132,18 +142,18 @@ export default [
   // WP4-4: Boundary files exempt from camelcase rule (snake_case allowed)
   {
     files: [
-      'src/lib/normalize/**/*.js',
-      'src/lib/ApiAdapter.js',
-      'src/lib/backend/**/*.js',
+      'src/lib/normalize/**/*.{js,ts}',
+      'src/lib/ApiAdapter.{js,ts}',
+      'src/lib/backend/**/*.{js,ts}',
     ],
     rules: {
       camelcase: 'off',
     },
   },
   // Architecture boundary: UI components should use @lib/api, not raw ApiAdapter
-  // Only applies to .jsx files (React components), not .js services
+  // Applies to React components (.jsx/.tsx), not .js/.ts services
   {
-    files: ['**/*.jsx'],
+    files: ['**/*.jsx', '**/*.tsx'],
     rules: {
       'no-restricted-imports': [
         'error',
@@ -314,6 +324,15 @@ export default [
               message:
                 'Admin/Courtboard must not import from registration. Use src/lib/ for shared code.',
             },
+            // NOTE: flat config does not merge no-restricted-imports across blocks
+            // (last match wins), so the ApiAdapter guard below is repeated here to
+            // keep it enforced for admin/courtboard. Backend access must go through
+            // the TennisBackend façade (src/lib/backend), not raw ApiAdapter.
+            {
+              group: ['**/ApiAdapter*'],
+              message:
+                'Use the TennisBackend façade (@lib/backend) instead of ApiAdapter directly.',
+            },
           ],
         },
       ],
@@ -375,27 +394,25 @@ export default [
   {
     files: [
       // Entry points — check window.Tennis readiness before rendering
-      'src/registration/main.jsx',
       'src/registration/main.tsx',
-      'src/admin/main.jsx',
+      'src/admin/main.tsx',
       // Bootstrap scripts extracted from inline HTML for CSP compliance
       'src/registration/bootstrap/**/*.js',
       'src/registration/bootstrap/**/*.ts',
       // Legacy interop — use window.Tennis directly (migrate to windowBridge over time)
-      'src/registration/utils/helpers.js',
       'src/registration/utils/helpers.ts',
-      'src/admin/handlers/courtOperations.js',
-      'src/admin/ai/AIAssistantAdmin.jsx',
+      'src/admin/handlers/courtOperations.ts',
+      'src/admin/ai/AIAssistantAdmin.tsx',
       // Singleton guard uses window[key] assignment pattern
-      'src/admin/hooks/useAdminSettings.js',
+      'src/admin/hooks/useAdminSettings.ts',
       // Courtboard entry point — polls window.Tennis readiness before rendering
-      'src/courtboard/main.jsx',
+      'src/courtboard/main.tsx',
       // Courtboard IIFE/plain scripts — direct window access required (ADR-006)
       'src/courtboard/bootstrap/**/*.js',
       'src/courtboard/debug-panel.js',
       // Courtboard bridges — single writer for window.CourtboardState / CourtAvailability
+      // (window-bridge.ts manages no-restricted-properties via precise inline disables)
       'src/courtboard/bridge/**/*.js',
-      'src/courtboard/browser-bridge.js',
     ],
     rules: {
       'no-restricted-globals': 'off',
@@ -409,9 +426,9 @@ export default [
   // IIFE/plain scripts are exempted above; this block re-enables the rule for ESM only.
   {
     files: [
-      'src/courtboard/components/**/*.{js,jsx}',
-      'src/courtboard/hooks/**/*.{js,jsx}',
-      'src/courtboard/mobile/**/*.{js,jsx}',
+      'src/courtboard/components/**/*.{js,jsx,ts,tsx}',
+      'src/courtboard/hooks/**/*.{js,jsx,ts,tsx}',
+      'src/courtboard/mobile/**/*.{js,jsx,ts,tsx}',
     ],
     rules: {
       'no-restricted-properties': [

--- a/tests/unit/api/ApiAdapter.test.ts
+++ b/tests/unit/api/ApiAdapter.test.ts
@@ -639,7 +639,7 @@ describe('ApiAdapter', () => {
 
       // Prime settings cache
       const first = await adapter.getSettings();
-      expect(first.settings.courtCount).toBe(12);
+      expect((first as { settings: { courtCount: number } }).settings.courtCount).toBe(12);
 
       // Mutate — should fully invalidate cache (data AND timestamp)
       await adapter.updateSettings({ courtCount: 10 });
@@ -647,7 +647,7 @@ describe('ApiAdapter', () => {
       // Next call must re-fetch from API (not return stale null from cache)
       const refreshed = await adapter.getSettings();
       expect(refreshed).not.toBeNull();
-      expect(refreshed.settings.courtCount).toBe(10);
+      expect((refreshed as { settings: { courtCount: number } }).settings.courtCount).toBe(10);
 
       // 3 fetches: initial getSettings + updateSettings + re-fetched getSettings
       expect(mockFn).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
## Summary

Several architecture-boundary lint rules were scoped to `.js`/`.jsx` globs that no longer match anything after the JS→TS migration, so they had been silently **failing open**. This PR re-points them at `.ts`/`.tsx`, prunes dead exempt-list entries, and works around a flat-config gotcha where `no-restricted-imports` does not merge across config blocks (last match wins).

### `eslint.config.js`
- Enable `camelcase` on the `.ts` and `.tsx` blocks (boundary files remain exempt).
- Widen the camelCase boundary exemption to cover `src/lib/normalize/**`, `src/lib/ApiAdapter.{js,ts}`, and `src/lib/backend/**`.
- Widen the ApiAdapter import guard from `.jsx` to also cover `.tsx`.
- Re-assert the ApiAdapter guard inside the admin/courtboard `no-restricted-imports` block — flat config does **not** merge `no-restricted-imports` across blocks (last match wins), so it was being shadowed. Comment added explaining this.
- Widen the courtboard ESM fence to `.{js,jsx,ts,tsx}`.
- Prune dead exempt-list entries (`.jsx`/`.js` paths that migrated to `.tsx`/`.ts`, plus a `browser-bridge.js` that no longer exists).

### `tests/unit/api/ApiAdapter.test.ts`
- Cast two `getSettings()` results (which return `unknown` via `_get`) at the `.settings.courtCount` access points, fixing 2 pre-existing TS18046 errors under `tsconfig.test.json`. Matches the file's existing `(e as AppError)` convention.

## Verification
- `npm run verify` passes end-to-end: lint ratchet (0 errors / 2 warnings, at baseline), type ratchet (0), test-type ratchet (0), coverage ratchet, fixtures, build, and e2e (22 passed).
- Confirmed the boundaries now bite: a throwaway `courtboard/components/*.tsx` importing ApiAdapter and reading `window.Tennis` produced 2 errors (vs 0 before this change); removed after testing.

## Known follow-up (not in this PR)
The same flat-config last-match-wins shadowing also drops the orchestration/backend import ban for `src/admin/screens/**`. Intentionally left out to keep this PR focused — it needs its own blast-radius check.

## Test plan
- [ ] CI runs `npm run verify` green on a clean checkout
- [ ] Reviewer confirms no legitimate import/identifier is newly blocked