### PR TITLE
refactor: replace presenter `: Function` types with real callback sig…

### DIFF
--- a/src/admin/hooks/useNotification.ts
+++ b/src/admin/hooks/useNotification.ts
@@ -10,10 +10,13 @@ import { createShowNotification } from './notificationLogic';
 /**
  * Hook for managing notification state and display.
  *
- * @returns {{ notification: Object|null, showNotification: Function }}
+ * @returns {{ notification: Object|null, showNotification: (message: string, type?: string) => void }}
  */
 export function useNotification() {
-  interface NotificationState { message: string; type: string; }
+  interface NotificationState {
+    message: string;
+    type: string;
+  }
   const [notification, setNotification] = useState<NotificationState | null>(null);
 
   // Create stable showNotification function

--- a/src/registration/router/presenters/courtPresenter.ts
+++ b/src/registration/router/presenters/courtPresenter.ts
@@ -7,7 +7,15 @@
  * Extracted from CourtRoute.jsx — maintains exact prop mapping.
  */
 
-import type { AppState, CourtDataMutable, DisplacementInfo, GroupPlayer, Handlers, OriginalCourtData, UpcomingBlock } from '../../../types/appTypes.js';
+import type {
+  AppState,
+  CourtDataMutable,
+  DisplacementInfo,
+  GroupPlayer,
+  Handlers,
+  OriginalCourtData,
+  UpcomingBlock,
+} from '../../../types/appTypes.js';
 import { logger } from '../../../lib/logger';
 
 /** Workflow-owned fields that buildCourtModel and buildCourtActions read. */
@@ -61,7 +69,7 @@ export interface CourtActions {
   onJoinWaitlist: () => Promise<void>;
   onAssignNext: () => void;
   onGoBack: () => void;
-  onStartOver: Function;
+  onStartOver: Handlers['resetForm'];
   onJoinWaitlistDeferred: () => void;
 }
 
@@ -71,7 +79,11 @@ export interface CourtActions {
  * Workflow-owned fields come from the `workflow` parameter (WorkflowContext).
  * Shell/global fields come from `app`.
  */
-export function buildCourtModel(app: AppState, workflow: CourtWorkflow, computed: CourtModelComputed): CourtModel {
+export function buildCourtModel(
+  app: AppState,
+  workflow: CourtWorkflow,
+  computed: CourtModelComputed
+): CourtModel {
   // Shell fields from app
   const { derived } = app;
   const { isMobileView } = derived;
@@ -112,21 +124,14 @@ export function buildCourtActions(
   const { isChangingCourt, displacement, originalCourtData } = workflow;
   const { justAssignedCourt } = workflow.courtAssignment;
   const { currentGroup } = workflow.groupGuest;
-  const {
-    setDisplacement,
-    setIsChangingCourt,
-    setWasOvertimeCourt,
-    setOriginalCourtData,
-  } = workflow;
+  const { setDisplacement, setIsChangingCourt, setWasOvertimeCourt, setOriginalCourtData } =
+    workflow;
 
   // Shell fields from app
   const { mobile, refs, setters, CONSTANTS } = app;
   const { mobileFlow } = mobile;
   const { successResetTimerRef } = refs;
-  const {
-    setShowSuccess,
-    setCurrentScreen,
-  } = setters;
+  const { setShowSuccess, setCurrentScreen } = setters;
 
   // Destructure from handlers
   const {

--- a/src/registration/router/presenters/groupPresenter.ts
+++ b/src/registration/router/presenters/groupPresenter.ts
@@ -11,7 +11,17 @@
  * Shell/global fields continue to come from `app`.
  */
 
-import type { AppState, CourtSelectionResult, FrequentPartner, GroupPlayer, Handlers, RegistrationConstants, RegistrationUiState } from '../../../types/appTypes.js';
+import type {
+  AppState,
+  CourtSelectionResult,
+  FrequentPartner,
+  GroupGuestState,
+  GroupPlayer,
+  Handlers,
+  RegistrationConstants,
+  RegistrationUiState,
+  SearchState,
+} from '../../../types/appTypes.js';
 
 /** Workflow-owned fields that buildGroupModel and buildGroupActions read. */
 export interface GroupWorkflow {
@@ -22,9 +32,9 @@ export interface GroupWorkflow {
     guestSponsor: string;
     showGuestNameError: boolean;
     showSponsorError: boolean;
-    handleRemovePlayer: Function;
-    handleSelectSponsor: Function;
-    handleCancelGuest: Function;
+    handleRemovePlayer: GroupGuestState['handleRemovePlayer'];
+    handleSelectSponsor: GroupGuestState['handleSelectSponsor'];
+    handleCancelGuest: GroupGuestState['handleCancelGuest'];
   };
   memberIdentity: {
     memberNumber: string;
@@ -69,35 +79,35 @@ export interface GroupModel {
   showGuestNameError: boolean;
   showSponsorError: boolean;
   // Utilities (data)
-  getAutocompleteSuggestions: Function;
+  getAutocompleteSuggestions: SearchState['getAutocompleteSuggestions'];
   CONSTANTS: RegistrationConstants;
 }
 
 export interface GroupActions {
   // Callbacks (renamed to on* convention)
-  onSearchChange: Function;
-  onSearchFocus: Function;
-  onSuggestionClick: Function;
-  onAddPlayerSearchChange: Function;
-  onAddPlayerSearchFocus: Function;
-  onAddPlayerSuggestionClick: Function;
-  onToggleAddPlayer: Function;
-  onToggleGuestForm: Function;
-  onRemovePlayer: Function;
-  onSelectSponsor: Function;
-  onGuestNameChange: Function;
-  onAddGuest: Function;
-  onCancelGuest: Function;
-  onAddFrequentPartner: Function;
-  onSelectCourt: Function;
+  onSearchChange: SearchState['handleGroupSearchChange'];
+  onSearchFocus: SearchState['handleGroupSearchFocus'];
+  onSuggestionClick: Handlers['handleGroupSuggestionClick'];
+  onAddPlayerSearchChange: SearchState['handleAddPlayerSearchChange'];
+  onAddPlayerSearchFocus: SearchState['handleAddPlayerSearchFocus'];
+  onAddPlayerSuggestionClick: Handlers['handleAddPlayerSuggestionClick'];
+  onToggleAddPlayer: Handlers['handleToggleAddPlayer'];
+  onToggleGuestForm: Handlers['handleToggleGuestForm'];
+  onRemovePlayer: GroupGuestState['handleRemovePlayer'];
+  onSelectSponsor: GroupGuestState['handleSelectSponsor'];
+  onGuestNameChange: Handlers['handleGuestNameChange'];
+  onAddGuest: Handlers['handleAddGuest'];
+  onCancelGuest: GroupGuestState['handleCancelGuest'];
+  onAddFrequentPartner: Handlers['addFrequentPartner'];
+  onSelectCourt: Handlers['handleGroupSelectCourt'];
   isAssigning: boolean;
-  onJoinWaitlist: Function;
+  onJoinWaitlist: Handlers['handleGroupJoinWaitlist'];
   joiningWaitlist: boolean;
-  onGoBack: Function;
-  onStartOver: Function;
+  onGoBack: Handlers['handleGroupGoBack'];
+  onStartOver: Handlers['resetForm'];
   // Utilities (functions)
-  isPlayerAlreadyPlaying: Function;
-  sameGroup: Function;
+  isPlayerAlreadyPlaying: Handlers['isPlayerAlreadyPlaying'];
+  sameGroup: Handlers['sameGroup'];
 }
 
 /**
@@ -184,7 +194,11 @@ export function buildGroupModel(app: AppState, workflow: GroupWorkflow): GroupMo
  * Workflow-owned reads/pass-throughs come from the `workflow` parameter.
  * Shell/handler fields come from `app` and `handlers`.
  */
-export function buildGroupActions(app: AppState, workflow: GroupWorkflow, handlers: Handlers): GroupActions {
+export function buildGroupActions(
+  app: AppState,
+  workflow: GroupWorkflow,
+  handlers: Handlers
+): GroupActions {
   // Workflow fields from context
   const { isAssigning, isJoiningWaitlist } = workflow;
   const { handleRemovePlayer, handleSelectSponsor, handleCancelGuest } = workflow.groupGuest;

--- a/src/registration/router/presenters/successPresenter.ts
+++ b/src/registration/router/presenters/successPresenter.ts
@@ -15,7 +15,18 @@
  * Shell/global fields continue to come from `app`.
  */
 
-import type { AppState, CommandResponse, DirectoryMember, DomainCourt, GroupPlayer, Handlers, ReplacedGroup, TennisConfig, UpcomingBlock } from '../../../types/appTypes.js';
+import type {
+  AppState,
+  BlockAdminState,
+  CommandResponse,
+  DirectoryMember,
+  DomainCourt,
+  GroupPlayer,
+  Handlers,
+  ReplacedGroup,
+  TennisConfig,
+  UpcomingBlock,
+} from '../../../types/appTypes.js';
 import { logger } from '../../../lib/logger';
 
 type PurchaseBallsOptions = { splitBalls?: boolean; splitAccountIds?: string[] | null };
@@ -69,17 +80,24 @@ export interface SuccessModel {
   ballPriceCents: number | null;
   // Utilities
   TENNIS_CONFIG: TennisConfig;
-  getCourtBlockStatus: Function;
+  getCourtBlockStatus: BlockAdminState['getCourtBlockStatus'];
   upcomingBlocks?: UpcomingBlock[];
   blockWarningMinutes: number | null;
 }
 
 export interface SuccessActions {
-  onChangeCourt: Function;
-  onHome: Function;
-  onPurchaseBalls: (sessionId: string, accountId: string, options?: PurchaseBallsOptions) => Promise<CommandResponse>;
+  onChangeCourt: Handlers['changeCourt'];
+  onHome: Handlers['resetForm'];
+  onPurchaseBalls: (
+    sessionId: string,
+    accountId: string,
+    options?: PurchaseBallsOptions
+  ) => Promise<CommandResponse>;
   onLookupMemberAccount: (memberNumber: string) => Promise<DirectoryMember[]>;
-  onUpdateSessionTournament: (sessionId: string, isTournamentFlag: boolean) => Promise<CommandResponse>;
+  onUpdateSessionTournament: (
+    sessionId: string,
+    isTournamentFlag: boolean
+  ) => Promise<CommandResponse>;
 }
 
 /**
@@ -88,7 +106,11 @@ export interface SuccessActions {
  * Workflow-owned fields come from the `workflow` parameter (WorkflowContext).
  * Shell/global fields come from `app`.
  */
-export function buildSuccessModel(app: AppState, workflow: SuccessWorkflow, computed: SuccessModelComputed): SuccessModel {
+export function buildSuccessModel(
+  app: AppState,
+  workflow: SuccessWorkflow,
+  computed: SuccessModelComputed
+): SuccessModel {
   // Shell fields from app
   const { state, mobile, admin, TENNIS_CONFIG } = app;
   const { blockAdmin } = admin;
@@ -97,7 +119,8 @@ export function buildSuccessModel(app: AppState, workflow: SuccessWorkflow, comp
   const { mobileFlow, mobileCountdown } = mobile;
 
   // Workflow fields from context
-  const { replacedGroup, canChangeCourt, changeTimeRemaining, isTimeLimited, timeLimitReason } = workflow;
+  const { replacedGroup, canChangeCourt, changeTimeRemaining, isTimeLimited, timeLimitReason } =
+    workflow;
   const { justAssignedCourt, assignedSessionId, assignedEndTime } = workflow.courtAssignment;
   const { registrantStreak } = workflow.streak;
   const { currentGroup } = workflow.groupGuest;
@@ -145,7 +168,11 @@ export function buildSuccessActions(app: AppState, handlers: Handlers): SuccessA
   return {
     onChangeCourt: changeCourt,
     onHome: resetForm,
-    onPurchaseBalls: async (sessionId: string, accountId: string, options?: PurchaseBallsOptions) => {
+    onPurchaseBalls: async (
+      sessionId: string,
+      accountId: string,
+      options?: PurchaseBallsOptions
+    ) => {
       logger.debug('SuccessRoute', 'Ball purchase handler called', {
         sessionId,
         accountId,


### PR DESCRIPTION
## Summary

The presenter interfaces (group/success/court) typed 28 callback props as `: Function`, which is effectively `any` for callables — it erases argument and return checking at exactly the layer seams most prone to break during refactors, undermining the strictNullChecks investment elsewhere.

The authoritative handler/state interfaces (`Handlers`, `SearchState`, `BlockAdminState`, `GroupGuestState`) already carry precise inline signatures, so each presenter prop now uses **indexed access** into its source (e.g. `onStartOver: Handlers['resetForm']`). This keeps a single source of truth — the presenter contract tracks the handler/state contract and can't silently drift. Also corrected a stale `Function` in `useNotification`'s JSDoc `@returns` (not a real annotation, so no type safety was lost there).

### Files
- `groupPresenter.ts` — 24 props → `Handlers[...]` / `SearchState[...]` / `GroupGuestState[...]`
- `successPresenter.ts` — `getCourtBlockStatus` → `BlockAdminState[...]`; `onChangeCourt`/`onHome` → `Handlers[...]`
- `courtPresenter.ts` — `onStartOver` → `Handlers['resetForm']`
- `useNotification.ts` — corrected stale JSDoc

### Out of scope
The 9 remaining `: Function`s in `global.d.ts` are the `window.Tennis.*` legacy interop bags (`[key: string]: any`) under ADR-006 containment; tightening them fights that boundary for little gain.

## Verification
`npm run verify` green end-to-end: lint/type/test-type ratchets at baseline, 176 unit test files, build, and 22 e2e specs.

## Test plan
- [ ] CI runs `npm run verify` green on a clean checkout
- [ ] Reviewer confirms the indexed-access types match each prop's runtime source